### PR TITLE
chore: demo with typedef

### DIFF
--- a/playground/base/nuxt.schema.ts
+++ b/playground/base/nuxt.schema.ts
@@ -4,6 +4,17 @@ export default defineNuxtConfigSchema({
     base: 'from base/nuxt.schema',
     colors: {
       $resolve: (value = []) => ['gray'].concat(value)
-    }
+    },
+    /**
+     * Links to be added somewhere
+     *
+     * @typedef Link
+     * @property {string} icon - Icon name
+     * @property {string} href - Link when clicking on the icon
+     * @property {number} label - Label of the icon
+     *
+     * @type {Link[]}
+     */
+    links: []
   }
 })


### PR DESCRIPTION
Demo of using with `@typedef`.

```ts
/**
 * Links to be added somewhere
 * 
 * @property {string} icon - Icon name
 * 
 * @property {string} href - Link when clicking on the icon
 * 
 * @property {number} label - Label of the icon
*/
links?: Link[],
```

The `.nuxt/schema/nuxt.schema.d.ts` looks like this:
<img width="592" alt="CleanShot 2022-12-07 at 19 23 28@2x" src="https://user-images.githubusercontent.com/904724/206265009-2f1dcc03-c10c-433b-b7ed-4beb1c088310.png">

But sadly the `Link` interface is not defined anywhere.

This created a wrong DX in the `playground/app.config.ts`:
<img width="1007" alt="CleanShot 2022-12-07 at 19 23 19@2x" src="https://user-images.githubusercontent.com/904724/206265106-4334c7cc-b541-46b7-8bf1-c2bad854df0a.png">
